### PR TITLE
Update RemoveWatermark.py

### DIFF
--- a/RemoveWatermark.py
+++ b/RemoveWatermark.py
@@ -24,8 +24,8 @@ def remove_watermark(path):
         try:
             with open(path,"rb") as f:
                 pdf_bin_data = f.read()
-                pdf_bin_data = pdf_bin_data.replace(binascii.unhexlify(hex_link_pat),"")
-                pdf_bin_data = pdf_bin_data.replace(binascii.unhexlify(hex_text_pat),"")
+                pdf_bin_data = pdf_bin_data.replace(binascii.unhexlify(hex_link_pat),b"")
+                pdf_bin_data = pdf_bin_data.replace(binascii.unhexlify(hex_text_pat),b"")
         except IOError:
             sys.stderr.write("Error in opening file")
     else:


### PR DESCRIPTION
Fixes pyton 3.x compatibility.

Source: https://stackoverflow.com/questions/42612002/python-sockets-error-typeerror-a-bytes-like-object-is-required-not-str-with